### PR TITLE
Create robots.txt - block AI training

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,49 @@
+Sitemap: https://isithotrightnow.com/sitemap.xml
+
+# list of ai bots from https://robotstxt.com/ai
+
+User-Agent: GPTBot
+User-Agent: ClaudeBot
+User-Agent: Claude-Web
+User-Agent: CCBot
+User-Agent: Google-Extended
+User-Agent: Applebot-Extended
+User-Agent: Facebookbot
+User-Agent: Meta-ExternalAgent
+User-Agent: Meta-ExternalFetcher
+User-Agent: diffbot
+User-Agent: PerplexityBot
+User-Agent: Omgili
+User-Agent: Omgilibot
+User-Agent: webzio-extended
+User-Agent: ImagesiftBot
+User-Agent: Bytespider
+User-Agent: Amazonbot
+User-Agent: Youbot
+User-Agent: SemrushBot-OCOB
+User-Agent: Petalbot
+User-Agent: VelenPublicWebCrawler
+User-Agent: TurnitinBot
+User-Agent: Timpibot
+User-Agent: OAI-SearchBot
+User-Agent: ICC-Crawler
+User-Agent: AI2Bot
+User-Agent: AI2Bot-Dolma
+User-Agent: DataForSeoBot
+User-Agent: AwarioBot
+User-Agent: AwarioSmartBot
+User-Agent: AwarioRssBot
+User-Agent: Google-CloudVertexBot
+User-Agent: PanguBot
+User-Agent: Kangaroo Bot
+User-Agent: Sentibot
+User-Agent: img2dataset
+User-Agent: Meltwater
+User-Agent: Seekr
+User-Agent: peer39_crawler
+User-Agent: cohere-ai
+User-Agent: cohere-training-data-crawler
+User-Agent: DuckAssistBot
+User-Agent: Scrapy
+Disallow: /
+DisallowAITraining: /


### PR DESCRIPTION
This is not an exhaustive list, and it won't stop disreputable scrapers that ignore robots.txt, but it might be worth putting in now before we get hit — we can't afford unlimited bandwidth! Our site is also largely dynamic content, so there's no real public good in allowing scrapers on our site. What do you think, @matlipson and @SteefanContractor?

If we add it, we should probably monitor traffic for a week or two afterward to make sure we haven't also killed our search traffic.