### PR TITLE
Update _quarto.yml

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -8,6 +8,7 @@ project:
 
 website:
   title: "Is it hot right now?"
+  site-url: "https://isithotrightnow.com"
   search:
     type: textbox
   google-analytics: "G-3EDWFZHK7Y"


### PR DESCRIPTION
I've found on a couple of other Netlify-hosted sites I run that omitting `site-url` from the Quarto configuration can cause problems with images and JavaScript resources when trailing slashes are omitted from URLs by users (eg. going to `isithotrightnow.com/places/melbourne` instead of `isithotrightnow.com/places/melbourne/`). Happy to merge, @matlipson and @SteefanContractor?